### PR TITLE
indentation, code segment origin, python3

### DIFF
--- a/src/etrace
+++ b/src/etrace
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # $Revision: 2.1 $
 
 import string, os, sys, stat, re
@@ -86,10 +86,10 @@ class Printer:
         self.level = self.level - 1
 
     def print_func(self, name):
-        print ("\n   " + self.level*"|\t" + "\--" + name, )
+        print ("\n   " + self.level*" \t" + "\--" + name, end = '')
 
     def print_totals(self):
-        print ("(total: %d times)" % (self.count+1), )
+        print (" (total: %d times)" % (self.count+1), end = '')
 
     def do_func(self, name):
         if self.prevname == name:
@@ -116,6 +116,7 @@ class Printer:
             if name == "main":
                 if self.count > 0:
                     self.print_totals()
+                print()
                 end_trace()
 
 # Main

--- a/src/ptrace.c
+++ b/src/ptrace.c
@@ -85,6 +85,8 @@
 /** Initial trace open */
 static FILE *__GNU_PTRACE_FILE__;
  
+/** Code segment */
+static void *segment;
 
 /** Final trace close */
 static void
@@ -105,6 +107,7 @@ gnu_ptrace_init(void)
 {
 	struct stat sta;
 	__GNU_PTRACE_FILE__ = NULL;
+	FILE *f;
 
 	/* See if a trace file exists */
 	if (stat(PTRACE_PIPENAME, &sta) != 0) 
@@ -132,6 +135,11 @@ gnu_ptrace_init(void)
 
 		/* Tracing requested: a trace file was found */
 		atexit(gnu_ptrace_close);
+
+		f = fopen("/proc/self/maps", "r");
+		fscanf(f, "%x", &segment);
+		fclose(f);
+
 		return 1;
 	}
 }
@@ -146,7 +154,7 @@ gnu_ptrace(char * what, void * p)
 
 	if (active == 0)
 		return;
-	
+
 	if (first)
 	{
 		active = gnu_ptrace_init();
@@ -155,8 +163,8 @@ gnu_ptrace(char * what, void * p)
 		if (active == 0)
 			return;
 	}
-	
-	fprintf(TRACE, "%s %p\n", what, p);
+
+	fprintf(TRACE, "%s %p\n", what, p - segment);
 	fflush(TRACE);
 	return;
 }

--- a/src/ptrace.c
+++ b/src/ptrace.c
@@ -40,7 +40,7 @@
 #if (__GNUC__>2) || ((__GNUC__ == 2) && (__GNUC_MINOR__ > 95))
 
 /*---------------------------------------------------------------------------
-   								Includes
+								Includes
  ---------------------------------------------------------------------------*/
 
 #include <stdio.h>
@@ -52,7 +52,7 @@
 #include <sys/errno.h>
 
 /*---------------------------------------------------------------------------
-   							    User Macros
+							    User Macros
  ---------------------------------------------------------------------------*/
 #define PTRACE_PIPENAME	 "TRACE"
 
@@ -65,7 +65,7 @@
 
 
 /*---------------------------------------------------------------------------
-   								Defines
+								Defines
  ---------------------------------------------------------------------------*/
 
 #define REFERENCE_OFFSET "REFERENCE:"
@@ -79,7 +79,7 @@
 #define GET(_x,_y)       _x(_y)
 #define TRACE __GNU_PTRACE_FILE__
 /*---------------------------------------------------------------------------
-  							Function codes
+							Function codes
  ---------------------------------------------------------------------------*/
 
 /** Initial trace open */
@@ -94,7 +94,7 @@ gnu_ptrace_close(void)
 	fprintf(TRACE, END_TRACE " %ld\n", (long)getpid());
 
 	if (TRACE != NULL)
-	    fclose(TRACE);
+		fclose(TRACE);
 	return ;
 }
 
@@ -104,36 +104,36 @@ __NON_INSTRUMENT_FUNCTION__
 gnu_ptrace_init(void)
 {
 	struct stat sta;
-    __GNU_PTRACE_FILE__ = NULL;
-    
+	__GNU_PTRACE_FILE__ = NULL;
+
 	/* See if a trace file exists */
 	if (stat(PTRACE_PIPENAME, &sta) != 0) 
 	{
-		/* No trace file: do not trace at all */
+			/* No trace file: do not trace at all */
 		return 0;
 	}
-	else 
+	else
 	{
-		/* trace file: open up trace file */
-    	if ((TRACE = fopen(PTRACE_PIPENAME, "a")) == NULL)
-    	{
-            char *msg = strerror(errno);
-            perror(msg);
-            printf("[gnu_ptrace error]\n");
-    		return 0;
-    	}
-	
-        #ifdef PTRACE_REFERENCE_FUNCTION
-        fprintf(TRACE,"%s %s %p\n",
-                  REFERENCE_OFFSET,
-                  GET(STR,PTRACE_REFERENCE_FUNCTION),
-                  (void *)GET(DEF,PTRACE_REFERENCE_FUNCTION));
-        #endif
-        
-    	/* Tracing requested: a trace file was found */
-    	atexit(gnu_ptrace_close);
-    	return 1;
-    }
+			/* trace file: open up trace file */
+		if ((TRACE = fopen(PTRACE_PIPENAME, "a")) == NULL)
+		{
+			char *msg = strerror(errno);
+			perror(msg);
+			printf("[gnu_ptrace error]\n");
+			return 0;
+		}
+
+		#ifdef PTRACE_REFERENCE_FUNCTION
+		fprintf(TRACE,"%s %s %p\n",
+			REFERENCE_OFFSET,
+			GET(STR,PTRACE_REFERENCE_FUNCTION),
+			(void *)GET(DEF,PTRACE_REFERENCE_FUNCTION));
+		#endif
+
+		/* Tracing requested: a trace file was found */
+		atexit(gnu_ptrace_close);
+		return 1;
+	}
 }
 
 /** Function called by every function event */
@@ -150,14 +150,14 @@ gnu_ptrace(char * what, void * p)
 	if (first)
 	{
 		active = gnu_ptrace_init();
-        first = 0;
-        
-        if (active == 0)
-            return;
+		first = 0;
+
+		if (active == 0)
+			return;
 	}
 	
 	fprintf(TRACE, "%s %p\n", what, p);
-    fflush(TRACE);
+	fflush(TRACE);
 	return;
 }
 


### PR DESCRIPTION
The ptrace.c did not work for me because the addresses it wrote to the pipe did not match the addresses  returned by nm. The second commit in this PR make them match by subtracting the address where the code segment starts.

At least the solution of finding that address reading /proc/self/maps is specific to Linux, so maybe some conditional compilation directive is needed? Does anyone else have had the same problem?