### PR TITLE
Allow to copy ptrace.c code into C++ codebase

### DIFF
--- a/src/ptrace.c
+++ b/src/ptrace.c
@@ -169,6 +169,10 @@ gnu_ptrace(char * what, void * p)
 	return;
 }
 
+#if __cplusplus
+extern "C" {
+#endif
+
 /** According to gcc documentation: called upon function entry */
 void
 __NON_INSTRUMENT_FUNCTION__
@@ -186,6 +190,10 @@ __cyg_profile_func_exit(void *this_fn, void *call_site)
 	gnu_ptrace(FUNCTION_EXIT, this_fn);
 	(void)call_site;
 }
+
+#if __cplusplus
+}
+#endif
 
 #endif
 /* vim: set ts=4 et sw=4 tw=75 */

--- a/src/ptrace.c
+++ b/src/ptrace.c
@@ -147,7 +147,7 @@ gnu_ptrace_init(void)
 /** Function called by every function event */
 void
 __NON_INSTRUMENT_FUNCTION__
-gnu_ptrace(char * what, void * p)
+gnu_ptrace(const char * what, void * p)
 {
 	static int first=1;
 	static int active=1;

--- a/src/ptrace.c
+++ b/src/ptrace.c
@@ -84,9 +84,9 @@
 
 /** Initial trace open */
 static FILE *__GNU_PTRACE_FILE__;
- 
-/** Code segment */
-static void *segment;
+
+/** Code segment offset */
+static size_t offset;
 
 /** Final trace close */
 static void
@@ -137,7 +137,7 @@ gnu_ptrace_init(void)
 		atexit(gnu_ptrace_close);
 
 		f = fopen("/proc/self/maps", "r");
-		fscanf(f, "%x", &segment);
+		fscanf(f, "%zx", &offset);
 		fclose(f);
 
 		return 1;
@@ -164,7 +164,7 @@ gnu_ptrace(char * what, void * p)
 			return;
 	}
 
-	fprintf(TRACE, "%s %p\n", what, p - segment);
+	fprintf(TRACE, "%s %p\n", what, (unsigned char *)p - offset);
 	fflush(TRACE);
 	return;
 }


### PR DESCRIPTION
### Changes

- add `extern "C"` to allow copying prace.c code into C++ codebase
- use `size_t` for reading segment offset (fix void pointer arithmetic)
- fix reading segment offset on 64-bit architectures